### PR TITLE
feat: Support  multi-level directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-pilet-service",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Piral: Sample pilet feed service.",
   "main": "dist",
   "typings": "dist",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const defaultProtocol = process.env.HTTPS ? 'https' : 'http';
 export const defaultPort = +(process.env.PORT || 9000);
 export const defaultPiletPath = `/api/v1/pilet`;
-export const defaultFilePath = '/files(/@:org)?/:name/:version/:file?';
+export const defaultFilePath = '/files(/@:org)?/:name/:version/((*/)?:file)?';


### PR DESCRIPTION
Support  multi-level directories such as `/files/sample-pilet/1.0.0/static/js/0.c0dcd813.chunk.js`